### PR TITLE
ZNC for Windows has moved to GitHub

### DIFF
--- a/znclinker.pm
+++ b/znclinker.pm
@@ -92,7 +92,7 @@ sub OnChanMsg {
 		$self->put_chan($chan=>"$to, ZNC is free software. Just install and use it. If you wanted a free BNC account instead, go somewhere else. http://wiki.znc.in/Providers may be a good start.");
 	}
 	if ($what=~/^!win/) {
-		$self->put_chan($chan=>'ZNC for Windows: http://code.google.com/p/znc-msvc/wiki/WikiStart?tm=6');
+		$self->put_chan($chan=>'ZNC for Windows: https://github.com/KiNgMaR/znc');
 	}
 	if ($what eq '!help') {
 		$self->put_chan($chan=>'Need any help?');


### PR DESCRIPTION
The old link says that ZNC for Windows has moved there. I cannot see exe there though, @KiNgMaR can probably tell where it is or add it to that project.