### PR TITLE
link !windows to cygwin instructions

### DIFF
--- a/znclinker.pm
+++ b/znclinker.pm
@@ -92,7 +92,7 @@ sub OnChanMsg {
 		$self->put_chan($chan=>"$to, ZNC is free software. Just install and use it. If you wanted a free BNC account instead, go somewhere else. http://wiki.znc.in/Providers may be a good start.");
 	}
 	if ($what=~/^!win/) {
-		$self->put_chan($chan=>'ZNC for Windows: http://code.google.com/p/znc-msvc/wiki/WikiStart?tm=6');
+		$self->put_chan($chan=>'Installing ZNC on Windows: http://wiki.znc.in/Installation#Cygwin');
 	}
 	if ($what eq '!help') {
 		$self->put_chan($chan=>'Need any help?');


### PR DESCRIPTION
It appears that the unofficial ZNC for Windows is dead and that is
probably the nearest equivalent.

Closes #10